### PR TITLE
Fix validate-typings not reporting failure via its exit code

### DIFF
--- a/validate-typings.js
+++ b/validate-typings.js
@@ -31,17 +31,30 @@ try {
     iPublicExportPlusSchema.parse(publicExportPlus);
     console.log("✅ Schemas validated successfully.");
 } catch (e) {
-    console.log((e as Error).message);
+    console.error((e as Error).message);
+    process.exit(1);
 }`;
 fs.writeFileSync("tmp-test.ts", test);
-execSync("npx ts-node tmp-test.ts", {
-  stdio: "inherit",
-  env: {
-    ...process.env,
-    TS_NODE_COMPILER_OPTIONS: JSON.stringify({ module: "commonjs" }),
-  },
-});
 
-fs.unlinkSync("tmp-schemas.ts");
-fs.unlinkSync("tmp-types.ts");
-fs.unlinkSync("tmp-test.ts");
+const tmpFiles = ["tmp-schemas.ts", "tmp-types.ts", "tmp-test.ts"];
+try {
+  execSync("npx ts-node tmp-test.ts", {
+    stdio: "inherit",
+    env: {
+      ...process.env,
+      TS_NODE_COMPILER_OPTIONS: JSON.stringify({ module: "commonjs" }),
+    },
+  });
+} catch (error) {
+  if (typeof error?.status === "number") {
+    process.exitCode = error.status;
+  } else {
+    process.exitCode = 1;
+  }
+} finally {
+  for (const file of tmpFiles) {
+    if (fs.existsSync(file)) {
+      fs.unlinkSync(file);
+    }
+  }
+}

--- a/validate-typings.js
+++ b/validate-typings.js
@@ -36,7 +36,6 @@ try {
 }`;
 fs.writeFileSync("tmp-test.ts", test);
 
-const tmpFiles = ["tmp-schemas.ts", "tmp-types.ts", "tmp-test.ts"];
 try {
   execSync("npx ts-node tmp-test.ts", {
     stdio: "inherit",
@@ -52,9 +51,7 @@ try {
     process.exitCode = 1;
   }
 } finally {
-  for (const file of tmpFiles) {
-    if (fs.existsSync(file)) {
-      fs.unlinkSync(file);
-    }
-  }
+  fs.unlinkSync("tmp-schemas.ts");
+  fs.unlinkSync("tmp-types.ts");
+  fs.unlinkSync("tmp-test.ts");
 }

--- a/validate-typings.js
+++ b/validate-typings.js
@@ -28,11 +28,11 @@ const test = `import { z } from "zod";
 import { iPublicExportPlusSchema } from "./tmp-schemas";
 import publicExportPlus from "./index";
 try {
-    iPublicExportPlusSchema.parse(publicExportPlus);
-    console.log("✅ Schemas validated successfully.");
+  iPublicExportPlusSchema.parse(publicExportPlus);
+  console.log("✅ Schemas validated successfully.");
 } catch (e) {
-    console.error((e as Error).message);
-    process.exit(1);
+  console.error((e as Error).message);
+  process.exit(1);
 }`;
 fs.writeFileSync("tmp-test.ts", test);
 


### PR DESCRIPTION
## Summary
- ensure the temporary test script exits with a non-zero status when schema validation fails
- wrap the ts-node invocation to propagate failure codes while still cleaning up temporary files

## Testing
- node validate-typings.js (fails as expected due to current schema issues)


------
https://chatgpt.com/codex/tasks/task_e_68f331d84348832580672420076ec726